### PR TITLE
Add PyTorch Tacotron2 + Vocoder

### DIFF
--- a/MultiBandMelGAN.h
+++ b/MultiBandMelGAN.h
@@ -9,13 +9,13 @@ private:
 
 
 public:
-	bool Initialize(const std::string& VocoderPath);
+    virtual bool Initialize(const std::string& VocoderPath);
 
 
 	// Do MultiBand MelGAN inference including PQMF
 	// -> InMel:  Mel spectrogram (shape [1, xx, 80])
 	// <- Returns: Tensor data [4, xx, 1]
-	TFTensor<float> DoInference(const TFTensor<float>& InMel);
+    virtual TFTensor<float> DoInference(const TFTensor<float>& InMel);
 
 	MultiBandMelGAN();
 	~MultiBandMelGAN();

--- a/TensorVox.pro
+++ b/TensorVox.pro
@@ -33,6 +33,7 @@ SOURCES += \
     ext/ZCharScanner.cpp \
     ext/ZFile.cpp \
     ext/qcustomplot.cpp \
+    istftnettorch.cpp \
     main.cpp \
     mainwindow.cpp \
     melgen.cpp \
@@ -43,6 +44,7 @@ SOURCES += \
     phonetichighlighter.cpp \
     spectrogram.cpp \
     tacotron2.cpp \
+    tacotron2torch.cpp \
     tfg2p.cpp \
     torchmoji.cpp \
     track.cpp \
@@ -77,6 +79,7 @@ HEADERS += \
     ext/ZFile.h \
     ext/json.hpp \
     ext/qcustomplot.h \
+    istftnettorch.h \
     mainwindow.h \
     melgen.h \
     modelinfodlg.h \
@@ -86,6 +89,7 @@ HEADERS += \
     phonetichighlighter.h \
     spectrogram.h \
     tacotron2.h \
+    tacotron2torch.h \
     tfg2p.h \
     torchmoji.h \
     track.h \

--- a/Voice.cpp
+++ b/Voice.cpp
@@ -158,8 +158,14 @@ Voice::Voice(const std::string & VoxPath, const std::string &inName, Phonemizer 
     else
         Vocoder = std::make_unique<MultiBandMelGAN>();
 
-    if (Vocoder)
+    if (Vocoder.get())
+    {
+
+
         Vocoder.get()->Initialize(VoxPath + "/vocoder");
+
+
+    }
 
 
 
@@ -222,7 +228,7 @@ VoxResults Voice::Vocalize(const std::string & Prompt, float Speed, int32_t Spea
     bool VoxIsTac = Text2MelN != EText2MelModel::FastSpeech2;
 
     std::string PromptToFeed = Prompt;
-    if (VoxInfo.LangType != ETTSLanguageType::Char)
+    if (VoxInfo.LangType != ETTSLanguageType::Char && Text2MelN != EText2MelModel::Tacotron2Torch)
         PromptToFeed += VoxInfo.EndPadding;
 
     std::string PhoneticTxt = Processor.ProcessTextPhonetic(PromptToFeed,Phonemes,CurrentDict,
@@ -232,6 +238,9 @@ VoxResults Voice::Vocalize(const std::string & Prompt, float Speed, int32_t Spea
     TFTensor<float> Attention;
 
     std::vector<int32_t> InputIDs;
+
+    if (Text2MelN == EText2MelModel::Tacotron2Torch)
+        PhoneticTxt += VoxInfo.EndPadding;
 
 
 
@@ -344,6 +353,8 @@ VoxResults Voice::Vocalize(const std::string & Prompt, float Speed, int32_t Spea
 
 
 
+    if (!AudioData.size())
+        QMessageBox::critical(nullptr,"f","ss");
 
     return {AudioData,Attention,Mel};
 }

--- a/Voice.h
+++ b/Voice.h
@@ -8,7 +8,7 @@
 #include "Numbertext.hxx"
 #include "torchmoji.h"
 #include "phoneticdict.h"
-
+#include "tacotron2torch.h"
 
 struct VoxResults{
   std::vector<float> Audio;

--- a/Voice.h
+++ b/Voice.h
@@ -9,7 +9,7 @@
 #include "torchmoji.h"
 #include "phoneticdict.h"
 #include "tacotron2torch.h"
-
+#include "istftnettorch.h"
 struct VoxResults{
   std::vector<float> Audio;
   TFTensor<float> Alignment;
@@ -20,7 +20,7 @@ class Voice
 {
 private:
     std::unique_ptr<MelGen> MelPredictor;
-	MultiBandMelGAN Vocoder;
+    std::unique_ptr<MultiBandMelGAN> Vocoder;
 	EnglishPhoneticProcessor Processor;
     VoiceInfo VoxInfo;
     TorchMoji Moji;

--- a/VoxCommon.cpp
+++ b/VoxCommon.cpp
@@ -141,7 +141,7 @@ VoiceInfo VoxUtil::ReadModelJSON(const std::string &InfoFilename)
     std::string EndToken = JS["pad"].get<std::string>();
 
     // If it's phonetic then it's the token str, like "@EOS"
-    if (LangType != ETTSLanguageType::Char && EndToken.size())
+    if (LangType != ETTSLanguageType::Char && EndToken.size() && CuArch.Text2Mel != EText2MelModel::Tacotron2Torch)
         EndToken =  " " + EndToken; // In this case we add a space for separation since we directly append the value to the prompt
 
 

--- a/VoxCommon.cpp
+++ b/VoxCommon.cpp
@@ -4,9 +4,9 @@ using namespace nlohmann;
 #include <codecvt>
 #include <locale>         // std::wstring_convert
 
-const std::vector<std::string> Text2MelNames = {"FastSpeech2","Tacotron2","VITS","VITS + TorchMoji"};
-const std::vector<std::string> VocoderNames = {"Multi-Band MelGAN","MelGAN-STFT",""};
-const std::vector<std::string> RepoNames = {"TensorflowTTS","Coqui-TTS","jaywalnut310"};
+const std::vector<std::string> Text2MelNames = {"FastSpeech2","Tacotron2 (TF)","VITS","VITS + TorchMoji","Tacotron2 (Torch)"};
+const std::vector<std::string> VocoderNames = {"Multi-Band MelGAN","MelGAN-STFT","","iSTFTNet"};
+const std::vector<std::string> RepoNames = {"TensorflowTTS","Coqui-TTS","jaywalnut310","keonlee9420"};
 
 const std::vector<std::string> LanguageNames = {"English","Spanish", "German", "EnglishIPA"};
 const std::vector<std::string> LangaugeNamesNumToWords = {"en", "es","de","en"};

--- a/VoxCommon.hpp
+++ b/VoxCommon.hpp
@@ -53,7 +53,8 @@ namespace ETTSRepo {
 enum Enum{
     TensorflowTTS = 0,
     CoquiTTS,
-    jaywalnut310 // OG VITS repo
+    jaywalnut310, // OG VITS repo
+    keonlee9420
 };
 
 }
@@ -62,7 +63,8 @@ enum Enum{
     FastSpeech2 = 0,
     Tacotron2,
     VITS,
-    VITSTM
+    VITSTM,
+    Tacotron2Torch
 };
 
 }
@@ -71,7 +73,8 @@ namespace EVocoderModel{
 enum Enum{
     MultiBandMelGAN = 0,
     MelGANSTFT, // there is no architectural changes so we can use mb-melgan class for melgan-stft
-    NullVocoder // For fully E2E models
+    NullVocoder, // For fully E2E models
+    iSTFTNet
 };
 }
 

--- a/espeakphonemizer.cpp
+++ b/espeakphonemizer.cpp
@@ -2,8 +2,8 @@
 #include <espeak/speak_lib.h>
 
 
-static const std::u32string Punctuation_t = U",.;¡!¿?:-";
-static const std::u32string Punctuation_ns = U"¿-";
+static const std::u32string Punctuation_t = U",.;¡!¿?:-~";
+static const std::u32string Punctuation_ns = U"¿-~";
 
 using namespace ESP;
 

--- a/istftnettorch.cpp
+++ b/istftnettorch.cpp
@@ -41,10 +41,11 @@ TFTensor<float> iSTFTNetTorch::DoInference(const TFTensor<float> &InMel)
     auto TorchMel = torch::tensor(InMel.Data,device).reshape(InMel.Shape).transpose(1,2); // [1, frames, n_mels] -> [1, n_mels, frames]
 
 
+
     try{
         at::Tensor Output = Model({TorchMel}).toTensor().squeeze(); // (audio frames)
         if (PostLoaded)
-            Output = Post({Output.unsqueeze(0)}).toTensor();
+            Output = Post({Output.unsqueeze(0).toType(at::ScalarType::Float)}).toTensor();
 
 
         TFTensor<float> Tens = VoxUtil::CopyTensor<float>(Output);
@@ -52,10 +53,10 @@ TFTensor<float> iSTFTNetTorch::DoInference(const TFTensor<float> &InMel)
 
         return Tens;
     }
-    catch (const c10::Error& e) {
+    catch (const std::exception& e) {
         int msgboxID = MessageBox(
             NULL,
-            (LPCWSTR)QString::fromStdString(e.what_without_backtrace()).toStdWString().c_str(),
+            (LPCWSTR)QString::fromStdString(e.what()).toStdWString().c_str(),
             (LPCWSTR)L"Account Details",
             MB_ICONWARNING | MB_CANCELTRYCONTINUE | MB_DEFBUTTON2
         );

--- a/istftnettorch.cpp
+++ b/istftnettorch.cpp
@@ -1,0 +1,37 @@
+#include "istftnettorch.h"
+
+bool iSTFTNetTorch::Initialize(const std::string &VocoderPath)
+{
+    try {
+        // Deserialize the ScriptModule from a file using torch::jit::load().
+
+        Model = torch::jit::load(VocoderPath + ".pt");
+
+    }
+    catch (const c10::Error& e) {
+        return false;
+
+    }
+
+    return true;
+
+}
+
+TFTensor<float> iSTFTNetTorch::DoInference(const TFTensor<float> &InMel)
+{
+    auto TorchMel = torch::tensor(InMel.Data).reshape(InMel.Shape).unsqueeze(0); // [1, frames, n_mels]
+
+
+    at::Tensor Output = Model({TorchMel}).toTensor(); // (audio frames)
+
+    TFTensor<float> Tens = VoxUtil::CopyTensor<float>(Output);
+
+    return Tens;
+
+
+}
+
+iSTFTNetTorch::iSTFTNetTorch()
+{
+
+}

--- a/istftnettorch.cpp
+++ b/istftnettorch.cpp
@@ -1,17 +1,33 @@
 #include "istftnettorch.h"
-
+#include <windows.h>
 bool iSTFTNetTorch::Initialize(const std::string &VocoderPath)
 {
+    torch::Device device(torch::kCPU);
+
     try {
         // Deserialize the ScriptModule from a file using torch::jit::load().
 
-        Model = torch::jit::load(VocoderPath + ".pt");
+        std::string VCP = VocoderPath + ".pt";
+
+        Model = torch::jit::load(VCP,device);
 
     }
     catch (const c10::Error& e) {
+        QMessageBox::critical(nullptr,"r",e.what_without_backtrace());
         return false;
 
     }
+    try{
+        std::string PostPath = VocoderPath + "-post.pt";
+        Post = torch::jit::load(PostPath,device);
+        PostLoaded = true;
+    }
+    catch (const c10::Error& e){
+        PostLoaded = false;
+
+    }
+
+
 
     return true;
 
@@ -19,14 +35,38 @@ bool iSTFTNetTorch::Initialize(const std::string &VocoderPath)
 
 TFTensor<float> iSTFTNetTorch::DoInference(const TFTensor<float> &InMel)
 {
-    auto TorchMel = torch::tensor(InMel.Data).reshape(InMel.Shape).unsqueeze(0); // [1, frames, n_mels]
+    // without this memory consumption is 4x
+    torch::NoGradGuard no_grad;
+    torch::Device device(torch::kCPU);
+    auto TorchMel = torch::tensor(InMel.Data,device).reshape(InMel.Shape).transpose(1,2); // [1, frames, n_mels] -> [1, n_mels, frames]
 
 
-    at::Tensor Output = Model({TorchMel}).toTensor(); // (audio frames)
+    try{
+        at::Tensor Output = Model({TorchMel}).toTensor().squeeze(); // (audio frames)
+        if (PostLoaded)
+            Output = Post({Output.unsqueeze(0)}).toTensor();
 
-    TFTensor<float> Tens = VoxUtil::CopyTensor<float>(Output);
 
-    return Tens;
+        TFTensor<float> Tens = VoxUtil::CopyTensor<float>(Output);
+
+
+        return Tens;
+    }
+    catch (const c10::Error& e) {
+        int msgboxID = MessageBox(
+            NULL,
+            (LPCWSTR)QString::fromStdString(e.what_without_backtrace()).toStdWString().c_str(),
+            (LPCWSTR)L"Account Details",
+            MB_ICONWARNING | MB_CANCELTRYCONTINUE | MB_DEFBUTTON2
+        );
+
+
+        return TFTensor<float>();
+
+    }
+
+
+
 
 
 }

--- a/istftnettorch.h
+++ b/istftnettorch.h
@@ -1,0 +1,22 @@
+#ifndef ISTFTNETTORCH_H
+#define ISTFTNETTORCH_H
+#include "MultiBandMelGAN.h"
+
+class iSTFTNetTorch : public MultiBandMelGAN
+{
+private:
+   torch::jit::script::Module Model;
+
+public:
+    bool Initialize(const std::string& VocoderPath);
+
+
+
+    // Do MultiBand MelGAN inference including PQMF
+    // -> InMel:  Mel spectrogram (shape [1, xx, 80])
+    // <- Returns: Tensor data  [frames]
+    virtual TFTensor<float> DoInference(const TFTensor<float>& InMel);
+    iSTFTNetTorch();
+};
+
+#endif // ISTFTNETTORCH_H

--- a/istftnettorch.h
+++ b/istftnettorch.h
@@ -6,6 +6,9 @@ class iSTFTNetTorch : public MultiBandMelGAN
 {
 private:
    torch::jit::script::Module Model;
+   torch::jit::script::Module Post;
+
+   bool PostLoaded;
 
 public:
     bool Initialize(const std::string& VocoderPath);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1753,7 +1753,7 @@ void MainWindow::on_actionPhonemize_filelist_triggered()
 
 QString MainWindow::PhonemizeStr(QString &Text, Voice &VoxIn)
 {
-    const QString punctuation = ",.;¡!¿?':-";
+    const QString punctuation = ",.;¡!¿?':- ";
 
 
 

--- a/tacotron2torch.cpp
+++ b/tacotron2torch.cpp
@@ -51,20 +51,22 @@ TFTensor<float> Tacotron2Torch::DoInference(const std::vector<int32_t> &InputIDs
 
 
     // Infer
-
     c10::IValue Output = Model(inputs);
+
 
     // Output = list (mel_outputs, mel_outputs_postnet, gate_outputs, alignments)
 
     auto OutputL = Output.toList();
 
-    auto MelTens = OutputL[1].get().toTensor().squeeze().transpose(0,1); // [1, frames, n_mels] -> [frames, n_mels] -> [n_mels, frames]
-    auto AttTens = OutputL[3].get().toTensor().squeeze(); // [1, dec_t, enc_t ] -> [dec_t, enc_t]
+    auto MelTens = OutputL[1].get().toTensor();
+    auto AttTens = OutputL[3].get().toTensor();//.transpose(1,2); // [1, dec_t, enc_t ] -> [1, enc_t, dec_t]
 
 
     Attention = VoxUtil::CopyTensor<float>(AttTens);
 
+
     return VoxUtil::CopyTensor<float>(MelTens);
+
 
 
 }

--- a/tacotron2torch.cpp
+++ b/tacotron2torch.cpp
@@ -1,0 +1,70 @@
+#include "tacotron2torch.h"
+
+Tacotron2Torch::Tacotron2Torch()
+{
+
+}
+
+bool Tacotron2Torch::Initialize(const std::string &SavedModelFolder, ETTSRepo::Enum InTTSRepo)
+{
+    try {
+        // Deserialize the ScriptModule from a file using torch::jit::load().
+
+        Model = torch::jit::load(SavedModelFolder);
+
+    }
+    catch (const c10::Error& e) {
+        return false;
+
+    }
+
+    CurrentRepo = InTTSRepo;
+    return true;
+
+}
+
+TFTensor<float> Tacotron2Torch::DoInference(const std::vector<int32_t> &InputIDs, const std::vector<float> &ArgsFloat, const std::vector<int32_t> ArgsInt, int32_t SpeakerID, int32_t EmotionID)
+{
+    // without this memory consumption is 4x
+    torch::NoGradGuard no_grad;
+
+
+    std::vector<int64_t> IInputIDs;
+    IInputIDs.assign(InputIDs.begin(),InputIDs.end());
+
+
+
+
+    torch::TensorOptions Opts = torch::TensorOptions().requires_grad(false);
+
+    // This Tacotron2 always takes in speaker IDs
+    if (SpeakerID == -1)
+        SpeakerID = 0;
+
+    auto InSpkid = torch::tensor({SpeakerID},Opts);
+    auto InIDS = torch::tensor(IInputIDs, Opts).unsqueeze(0);
+
+
+
+    std::vector<torch::jit::IValue> inputs{ InSpkid,InIDS};
+
+
+
+    // Infer
+
+    c10::IValue Output = Model(inputs);
+
+    // Output = list (mel_outputs, mel_outputs_postnet, gate_outputs, alignments)
+
+    auto OutputL = Output.toList();
+
+    auto MelTens = OutputL[1].get().toTensor().squeeze().transpose(0,1); // [1, frames, n_mels] -> [frames, n_mels] -> [n_mels, frames]
+    auto AttTens = OutputL[3].get().toTensor().squeeze(); // [1, dec_t, enc_t ] -> [dec_t, enc_t]
+
+
+    Attention = VoxUtil::CopyTensor<float>(AttTens);
+
+    return VoxUtil::CopyTensor<float>(MelTens);
+
+
+}

--- a/tacotron2torch.cpp
+++ b/tacotron2torch.cpp
@@ -30,8 +30,12 @@ TFTensor<float> Tacotron2Torch::DoInference(const std::vector<int32_t> &InputIDs
 
 
     std::vector<int64_t> IInputIDs;
-    IInputIDs.assign(InputIDs.begin(),InputIDs.end());
+    IInputIDs.reserve(InputIDs.size());
+    for (const int32_t& Id : InputIDs){
+        int64_t casted = (int64_t)Id;
+        IInputIDs.push_back(casted);
 
+    }
 
 
 

--- a/tacotron2torch.h
+++ b/tacotron2torch.h
@@ -28,7 +28,7 @@ public:
     -> InputIDs: Input IDs of tokens for inference
     -> SpeakerID: ID of the speaker in the model to do inference on. If single speaker, always leave at 0. If multispeaker, refer to your model.
 
-    <- Returns: TFTensor<float> with shape [n_mels, frames] containing contents of mel spectrogram.
+    <- Returns: TFTensor<float> with shape {1,<len of mel in frames>,80} containing contents of mel spectrogram.
     */
     TFTensor<float> DoInference(const std::vector<int32_t>& InputIDs,const std::vector<float>& ArgsFloat,const std::vector<int32_t> ArgsInt, int32_t SpeakerID = 0, int32_t EmotionID = -1);
 

--- a/tacotron2torch.h
+++ b/tacotron2torch.h
@@ -1,0 +1,37 @@
+#ifndef TACOTRON2TORCH_H
+#define TACOTRON2TORCH_H
+#include "melgen.h"
+
+class Tacotron2Torch : public MelGen
+{
+private:
+   torch::jit::script::Module Model;
+
+public:
+
+    TFTensor<float> Attention;
+
+
+    Tacotron2Torch();
+    /*
+    Initialize and load the model
+
+    -> SavedModelFolder: Folder where the TorchScript models are exported
+    <- Returns: (bool)Success
+    */
+    bool Initialize(const std::string& SavedModelFolder, ETTSRepo::Enum InTTSRepo);
+
+
+    /*
+    Do inference on a Tacotron2 model.
+
+    -> InputIDs: Input IDs of tokens for inference
+    -> SpeakerID: ID of the speaker in the model to do inference on. If single speaker, always leave at 0. If multispeaker, refer to your model.
+
+    <- Returns: TFTensor<float> with shape [n_mels, frames] containing contents of mel spectrogram.
+    */
+    TFTensor<float> DoInference(const std::vector<int32_t>& InputIDs,const std::vector<float>& ArgsFloat,const std::vector<int32_t> ArgsInt, int32_t SpeakerID = 0, int32_t EmotionID = -1);
+
+};
+
+#endif // TACOTRON2TORCH_H


### PR DESCRIPTION
This PR adds Tacotron2 support from a nice repo I forked, improved and exported to TorchScript.
https://github.com/ZDisket/Comprehensive-Tacotron2/tree/ATSA
https://github.com/ZDisket/iSTFT-Avocodo-pytorch/tree/faster

- [x] Make Tacotron2 work
- [x] Make iSTFT generator work
- [x] Make Post-Vocoder work (using part of a pretrained VITS model on the same voice to improve output audio)
- [x] blah blah blah